### PR TITLE
Redis 설정 최적화로 성능 저하 방지

### DIFF
--- a/src/main/java/com/backend/immilog/global/infrastructure/persistence/config/RedisConfig.java
+++ b/src/main/java/com/backend/immilog/global/infrastructure/persistence/config/RedisConfig.java
@@ -10,14 +10,12 @@ import org.springframework.data.redis.cache.RedisCacheWriter;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
 
-@EnableRedisRepositories
 @EnableCaching
 @Configuration
 public class RedisConfig {


### PR DESCRIPTION
### 작업 내용
- 본 프로젝트에선 Redis를 직접 RedisTemplate로 다루고있음. (KeyValueRepository 안씀)

- @EnableRedisRepositories를 제거하면서 Spring이 Redis Repository를 자동 스캔하지 않음
 → 불필요한 성능 저하 방지!

### 특이 사항
- 없음
