### PR TITLE
post / jobboard 쿼리 시 계층 별로 역할 분명히 구분 (CQRS 패턴)

### DIFF
--- a/src/main/java/com/backend/immilog/post/application/result/JobBoardResult.java
+++ b/src/main/java/com/backend/immilog/post/application/result/JobBoardResult.java
@@ -1,75 +1,121 @@
 package com.backend.immilog.post.application.result;
 
-import com.backend.immilog.post.domain.enums.Countries;
-import com.backend.immilog.post.domain.enums.Experience;
-import com.backend.immilog.post.domain.enums.Industry;
-import com.backend.immilog.post.domain.enums.PostStatus;
-import com.backend.immilog.post.domain.model.post.JobBoard;
-import com.backend.immilog.post.domain.model.post.JobBoardCompany;
-import com.backend.immilog.post.domain.model.post.PostInfo;
+import com.backend.immilog.post.domain.enums.*;
+import com.backend.immilog.post.domain.model.interaction.InteractionUser;
+import com.backend.immilog.post.domain.model.resource.PostResource;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
-@Builder
-public record JobBoardResult(
-        Long seq,
-        String title,
-        String content,
-        Long viewCount,
-        Long likeCount,
-        List<String> tags,
-        List<String> attachments,
-        List<Long> likeUsers,
-        List<Long> bookmarkUsers,
-        Countries country,
-        String region,
-        Industry industry,
-        LocalDateTime deadline,
-        Experience experience,
-        String salary,
-        Long companySeq,
-        String companyName,
-        String companyEmail,
-        String companyPhone,
-        String companyAddress,
-        String companyHomepage,
-        String companyLogo,
-        Long companyManagerUserSeq,
-        PostStatus status,
-        LocalDateTime createdAt
-) {
-    public JobBoard toDomain() {
-        PostInfo postInfo = PostInfo.builder()
-                .title(this.title)
-                .content(this.content)
-                .viewCount(this.viewCount)
-                .likeCount(this.likeCount)
-                .status(this.status)
-                .country(this.country)
-                .region(this.region)
-                .build();
+@Getter
+public class JobBoardResult {
+    private final Long seq;
+    private final String title;
+    private final String content;
+    private final Long viewCount;
+    private final Long likeCount;
+    private final List<String> tags = new ArrayList<>();
+    private final List<String> attachments = new ArrayList<>();
+    private final List<Long> likeUsers = new ArrayList<>();
+    private final List<Long> bookmarkUsers = new ArrayList<>();
+    private final Countries country;
+    private final String region;
+    private final Industry industry;
+    private final LocalDateTime deadline;
+    private final Experience experience;
+    private final String salary;
+    private final Long companySeq;
+    private final String companyName;
+    private final String companyEmail;
+    private final String companyPhone;
+    private final String companyAddress;
+    private final String companyHomepage;
+    private final String companyLogo;
+    private final Long companyManagerUserSeq;
+    private final PostStatus status;
+    private final LocalDateTime createdAt;
 
-        JobBoardCompany jobBoardCompany = JobBoardCompany.builder()
-                .companySeq(this.companySeq)
-                .industry(this.industry)
-                .experience(this.experience)
-                .deadline(this.deadline)
-                .salary(this.salary)
-                .company(this.companyName)
-                .companyEmail(this.companyEmail)
-                .companyPhone(this.companyPhone)
-                .companyAddress(this.companyAddress)
-                .companyHomepage(this.companyHomepage)
-                .companyLogo(this.companyLogo)
-                .build();
+    @Builder
+    public JobBoardResult(
+            Long seq,
+            String title,
+            String content,
+            Long viewCount,
+            Long likeCount,
+            List<String> tags,
+            List<String> attachments,
+            List<Long> likeUsers,
+            List<Long> bookmarkUsers,
+            Countries country,
+            String region,
+            Industry industry,
+            LocalDateTime deadline,
+            Experience experience,
+            String salary,
+            Long companySeq,
+            String companyName,
+            String companyEmail,
+            String companyPhone,
+            String companyAddress,
+            String companyHomepage,
+            String companyLogo,
+            Long companyManagerUserSeq,
+            PostStatus status,
+            LocalDateTime createdAt
+    ) {
+        this.seq = seq;
+        this.title = title;
+        this.content = content;
+        this.viewCount = viewCount;
+        this.likeCount = likeCount;
+        this.tags.addAll(tags);
+        this.attachments.addAll(attachments);
+        this.likeUsers.addAll(likeUsers);
+        this.bookmarkUsers.addAll(bookmarkUsers);
+        this.country = country;
+        this.region = region;
+        this.industry = industry;
+        this.deadline = deadline;
+        this.experience = experience;
+        this.salary = salary;
+        this.companySeq = companySeq;
+        this.companyName = companyName;
+        this.companyEmail = companyEmail;
+        this.companyPhone = companyPhone;
+        this.companyAddress = companyAddress;
+        this.companyHomepage = companyHomepage;
+        this.companyLogo = companyLogo;
+        this.companyManagerUserSeq = companyManagerUserSeq;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
 
-        return JobBoard.builder()
-                .seq(this.seq)
-                .userSeq(this.companyManagerUserSeq())
-                .jobBoardCompany(jobBoardCompany)
-                .postInfo(postInfo)
-                .build();
+
+    public void addInteractionUsers(List<InteractionUser> interactionUserList) {
+        this.likeUsers.addAll(interactionUserList.stream()
+                .filter(interactionUser -> interactionUser.getInteractionType().equals(InteractionType.LIKE))
+                .map(InteractionUser::getUserSeq)
+                .toList());
+        this.bookmarkUsers.addAll(interactionUserList.stream()
+                .filter(interactionUser -> interactionUser.getInteractionType().equals(InteractionType.BOOKMARK))
+                .map(InteractionUser::getUserSeq)
+                .toList()
+        );
+    }
+
+    public void addResources(List<PostResource> resources) {
+        this.tags.addAll(resources.stream()
+                .filter(resource -> resource.getResourceType().equals(ResourceType.TAG))
+                .map(PostResource::getContent)
+                .toList()
+        );
+        this.attachments.addAll(resources.stream()
+                .filter(resource -> resource.getResourceType().equals(ResourceType.ATTACHMENT))
+                .map(PostResource::getContent)
+                .toList()
+        );
     }
 }

--- a/src/main/java/com/backend/immilog/post/application/result/PostResult.java
+++ b/src/main/java/com/backend/immilog/post/application/result/PostResult.java
@@ -36,6 +36,7 @@ public final class PostResult {
     private final Categories category;
     private final PostStatus status;
     private final String createdAt;
+    private final String updatedAt;
     private String title;
     private String content;
     private String keyword;
@@ -62,6 +63,7 @@ public final class PostResult {
             Categories category,
             PostStatus status,
             String createdAt,
+            String updatedAt,
             String keyword
     ) {
         this.seq = seq;
@@ -88,6 +90,7 @@ public final class PostResult {
         this.category = category;
         this.status = status;
         this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
         this.keyword = keyword;
     }
 

--- a/src/main/java/com/backend/immilog/post/application/services/CommentUploadService.java
+++ b/src/main/java/com/backend/immilog/post/application/services/CommentUploadService.java
@@ -6,12 +6,9 @@ import com.backend.immilog.post.application.services.query.PostQueryService;
 import com.backend.immilog.post.domain.enums.ReferenceType;
 import com.backend.immilog.post.domain.model.comment.Comment;
 import com.backend.immilog.post.domain.model.post.Post;
-import com.backend.immilog.post.exception.PostException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.backend.immilog.post.exception.PostErrorCode.POST_NOT_FOUND;
 
 @Slf4j
 @Service
@@ -37,7 +34,7 @@ public class CommentUploadService {
             String referenceType,
             String content
     ) {
-        Post post = getPost(postSeq);
+        Post post = postQueryService.getPostById(postSeq);
         Post deletedPost = post.updateCommentCount();
         ReferenceType reference = ReferenceType.getByString(referenceType);
         Comment comment = Comment.of(userId, postSeq, content, reference);
@@ -45,9 +42,4 @@ public class CommentUploadService {
         commentCommandService.save(comment);
     }
 
-    private Post getPost(Long postSeq) {
-        return postQueryService
-                .getPostById(postSeq)
-                .orElseThrow(() -> new PostException(POST_NOT_FOUND));
-    }
 }

--- a/src/main/java/com/backend/immilog/post/application/services/PostDeleteService.java
+++ b/src/main/java/com/backend/immilog/post/application/services/PostDeleteService.java
@@ -34,18 +34,13 @@ public class PostDeleteService {
             Long userId,
             Long postSeq
     ) {
-        Post post = getPost(postSeq);
+        Post post = postQueryService.getPostById(postSeq);
         if (!Objects.equals(post.getUserSeq(), userId)) {
             throw new PostException(PostErrorCode.NO_AUTHORITY);
         }
         Post deletedPost = post.delete();
         postCommandService.save(deletedPost);
         postResourceCommandService.deleteAllByPostSeq(deletedPost.getSeq());
-    }
-
-    private Post getPost(Long postSeq) {
-        return postQueryService.getPostById(postSeq)
-                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/backend/immilog/post/application/services/PostInquiryService.java
+++ b/src/main/java/com/backend/immilog/post/application/services/PostInquiryService.java
@@ -7,7 +7,6 @@ import com.backend.immilog.post.application.services.query.PostQueryService;
 import com.backend.immilog.post.domain.enums.Categories;
 import com.backend.immilog.post.domain.enums.Countries;
 import com.backend.immilog.post.domain.enums.SortingMethods;
-import com.backend.immilog.post.exception.PostException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -17,8 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;
-
-import static com.backend.immilog.post.exception.PostErrorCode.POST_NOT_FOUND;
 
 @Slf4j
 @Service
@@ -53,9 +50,7 @@ public class PostInquiryService {
 
     @Transactional(readOnly = true)
     public PostResult getPostDetail(Long postSeq) {
-        PostResult post =  postQueryService
-                .getPostDetail(postSeq)
-                .orElseThrow(() -> new PostException(POST_NOT_FOUND));
+        PostResult post = postQueryService.getPostDetail(postSeq);
         List<CommentResult> comments = commentQueryService.getComments(postSeq);
         post.addComments(comments);
         return post;

--- a/src/main/java/com/backend/immilog/post/application/services/PostUpdateService.java
+++ b/src/main/java/com/backend/immilog/post/application/services/PostUpdateService.java
@@ -47,7 +47,7 @@ public class PostUpdateService {
             Long postSeq,
             PostUpdateCommand command
     ) {
-        Post post = getPost(postSeq);
+        Post post = postQueryService.getPostById(postSeq);
         if (!Objects.equals(post.getUserSeq(), userId)) {
             throw new PostException(PostErrorCode.NO_AUTHORITY);
         }
@@ -62,7 +62,7 @@ public class PostUpdateService {
     @Async
     @DistributedLock(key = VIEW_LOCK_KEY, identifier = "#postSeq", expireTime = 5)
     public void increaseViewCount(Long postSeq) {
-        Post post = getPost(postSeq);
+        Post post = postQueryService.getPostById(postSeq);
         Post updatedPost = post.increaseViewCount();
         postCommandService.save(updatedPost);
     }
@@ -123,11 +123,5 @@ public class PostUpdateService {
                     }
             );
         }
-    }
-
-    private Post getPost(Long postSeq) {
-        return postQueryService
-                .getPostById(postSeq)
-                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
     }
 }

--- a/src/main/java/com/backend/immilog/post/application/services/query/InteractionUserQueryService.java
+++ b/src/main/java/com/backend/immilog/post/application/services/query/InteractionUserQueryService.java
@@ -7,6 +7,7 @@ import com.backend.immilog.post.domain.repositories.InteractionUserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -29,6 +30,17 @@ public class InteractionUserQueryService {
                 userSeq,
                 postType,
                 interactionType
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<InteractionUser> getInteractionUsersByPostSeqList(
+            List<Long> resultSeqList,
+            PostType postType
+    ) {
+        return interactionUserRepository.getInteractionsByPostSeqList(
+                resultSeqList,
+                postType
         );
     }
 }

--- a/src/main/java/com/backend/immilog/post/application/services/query/JobBoardQueryService.java
+++ b/src/main/java/com/backend/immilog/post/application/services/query/JobBoardQueryService.java
@@ -5,20 +5,33 @@ import com.backend.immilog.post.application.result.JobBoardResult;
 import com.backend.immilog.post.domain.enums.Countries;
 import com.backend.immilog.post.domain.enums.Experience;
 import com.backend.immilog.post.domain.enums.Industry;
+import com.backend.immilog.post.domain.enums.PostType;
+import com.backend.immilog.post.domain.model.interaction.InteractionUser;
+import com.backend.immilog.post.domain.model.post.JobBoard;
+import com.backend.immilog.post.domain.model.resource.PostResource;
 import com.backend.immilog.post.domain.repositories.JobBoardRepository;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
+import java.util.List;
 
 @Service
 public class JobBoardQueryService {
     private final JobBoardRepository jobBoardRepository;
+    private final InteractionUserQueryService interactionUserQueryService;
+    private final PostResourceQueryService postResourceQueryService;
 
-    public JobBoardQueryService(JobBoardRepository jobBoardRepository) {
+    public JobBoardQueryService(
+            JobBoardRepository jobBoardRepository,
+            InteractionUserQueryService interactionUserQueryService,
+            PostResourceQueryService postResourceQueryService
+    ) {
         this.jobBoardRepository = jobBoardRepository;
+        this.interactionUserQueryService = interactionUserQueryService;
+        this.postResourceQueryService = postResourceQueryService;
     }
 
     @PerformanceMonitor
@@ -30,17 +43,53 @@ public class JobBoardQueryService {
             Experience experienceEnum,
             Pageable pageable
     ) {
-        return jobBoardRepository.getJobBoards(
+        Page<JobBoard> jobBoards = jobBoardRepository.getJobBoards(
                 countryEnum,
                 sortingMethod,
                 industryEnum,
                 experienceEnum,
                 pageable
         );
+        Page<JobBoardResult> jobBoardResults = jobBoards.map(JobBoard::toResult);
+        return assembleJobBoardResult(jobBoards, jobBoardResults);
     }
 
     @Transactional(readOnly = true)
-    public Optional<JobBoardResult> getJobBoardBySeq(Long jobBoardSeq) {
-        return jobBoardRepository.getJobBoardBySeq(jobBoardSeq);
+    public JobBoardResult getJobBoardBySeq(Long jobBoardSeq) {
+        Page<JobBoard> jobBoard = new PageImpl<>(List.of(jobBoardRepository.getJobBoardBySeq(jobBoardSeq)));
+        Page<JobBoardResult> jobBoards = jobBoard.map(JobBoard::toResult);
+        return assembleJobBoardResult(jobBoard, jobBoards).getContent().getFirst();
+    }
+
+    private Page<JobBoardResult> assembleJobBoardResult(
+            Page<JobBoard> jobBoards,
+            Page<JobBoardResult> jobBoardResults
+    ) {
+        List<Long> jobBoardSeqList = jobBoards.stream().map(JobBoard::getSeq).toList();
+
+        List<PostResource> postResources = postResourceQueryService.getResourcesByPostSeqList(
+                jobBoardSeqList,
+                PostType.JOB_BOARD
+        );
+
+        List<InteractionUser> interactionUsers = interactionUserQueryService.getInteractionUsersByPostSeqList(
+                jobBoardSeqList,
+                PostType.JOB_BOARD
+        );
+
+        return jobBoardResults.map(jobBoardResult -> {
+            List<PostResource> resources = postResources.stream()
+                    .filter(postResource -> postResource.getPostSeq().equals(jobBoardResult.getSeq()))
+                    .toList();
+
+            List<InteractionUser> interactionUserList = interactionUsers.stream()
+                    .filter(interactionUser -> interactionUser.getPostSeq().equals(jobBoardResult.getSeq()))
+                    .toList();
+
+            jobBoardResult.addInteractionUsers(interactionUserList);
+            jobBoardResult.addResources(resources);
+
+            return jobBoardResult;
+        });
     }
 }

--- a/src/main/java/com/backend/immilog/post/application/services/query/PostResourceQueryService.java
+++ b/src/main/java/com/backend/immilog/post/application/services/query/PostResourceQueryService.java
@@ -1,0 +1,26 @@
+package com.backend.immilog.post.application.services.query;
+
+import com.backend.immilog.post.domain.enums.PostType;
+import com.backend.immilog.post.domain.model.resource.PostResource;
+import com.backend.immilog.post.domain.repositories.PostResourceRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class PostResourceQueryService {
+    private final PostResourceRepository postResourceRepository;
+
+    public PostResourceQueryService(PostResourceRepository postResourceRepository) {
+        this.postResourceRepository = postResourceRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostResource> getResourcesByPostSeqList(
+            List<Long> postSeqList,
+            PostType postType
+    ) {
+        return postResourceRepository.findAllByPostSeqList(postSeqList, postType);
+    }
+}

--- a/src/main/java/com/backend/immilog/post/domain/model/post/JobBoard.java
+++ b/src/main/java/com/backend/immilog/post/domain/model/post/JobBoard.java
@@ -1,6 +1,7 @@
 package com.backend.immilog.post.domain.model.post;
 
 import com.backend.immilog.post.application.command.JobBoardUploadCommand;
+import com.backend.immilog.post.application.result.JobBoardResult;
 import com.backend.immilog.post.domain.enums.Countries;
 import com.backend.immilog.post.domain.enums.Experience;
 import com.backend.immilog.post.domain.enums.Industry;
@@ -124,4 +125,59 @@ public class JobBoard {
     public PostStatus getStatus() {return this.postInfo.status();}
 
     public Countries getCountry() {return this.postInfo.country();}
+
+    public JobBoardResult toResult() {
+        return JobBoardResult.builder()
+                .seq(this.seq)
+                .title(this.postInfo.title())
+                .content(this.postInfo.content())
+                .viewCount(this.postInfo.viewCount())
+                .likeCount(this.postInfo.likeCount())
+                .country(this.postInfo.country())
+                .region(this.postInfo.region())
+                .industry(this.jobBoardCompany.industry())
+                .experience(this.jobBoardCompany.experience())
+                .deadline(this.jobBoardCompany.deadline())
+                .salary(this.jobBoardCompany.salary())
+                .companySeq(this.jobBoardCompany.companySeq())
+                .companyName(this.jobBoardCompany.company())
+                .companyEmail(this.jobBoardCompany.companyEmail())
+                .companyPhone(this.jobBoardCompany.companyPhone())
+                .companyAddress(this.jobBoardCompany.companyAddress())
+                .companyHomepage(this.jobBoardCompany.companyHomepage())
+                .companyLogo(this.jobBoardCompany.companyLogo())
+                .status(this.postInfo.status())
+                .createdAt(this.createdAt)
+                .build();
+    }
+
+    public static JobBoard from(JobBoardResult jobBoardResult) {
+        return JobBoard.builder()
+                .seq(jobBoardResult.getSeq())
+                .userSeq(jobBoardResult.getCompanyManagerUserSeq())
+                .postInfo(PostInfo.builder()
+                        .title(jobBoardResult.getTitle())
+                        .content(jobBoardResult.getContent())
+                        .viewCount(jobBoardResult.getViewCount())
+                        .likeCount(jobBoardResult.getLikeCount())
+                        .status(jobBoardResult.getStatus())
+                        .country(jobBoardResult.getCountry())
+                        .region(jobBoardResult.getRegion())
+                        .build())
+                .jobBoardCompany(JobBoardCompany.builder()
+                        .companySeq(jobBoardResult.getCompanySeq())
+                        .industry(jobBoardResult.getIndustry())
+                        .experience(jobBoardResult.getExperience())
+                        .deadline(jobBoardResult.getDeadline())
+                        .salary(jobBoardResult.getSalary())
+                        .company(jobBoardResult.getCompanyName())
+                        .companyEmail(jobBoardResult.getCompanyEmail())
+                        .companyPhone(jobBoardResult.getCompanyPhone())
+                        .companyAddress(jobBoardResult.getCompanyAddress())
+                        .companyHomepage(jobBoardResult.getCompanyHomepage())
+                        .companyLogo(jobBoardResult.getCompanyLogo())
+                        .build())
+                .createdAt(jobBoardResult.getCreatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/backend/immilog/post/domain/model/post/Post.java
+++ b/src/main/java/com/backend/immilog/post/domain/model/post/Post.java
@@ -4,6 +4,7 @@ import com.backend.immilog.post.application.command.PostUploadCommand;
 import com.backend.immilog.post.application.result.PostResult;
 import com.backend.immilog.post.domain.enums.Badge;
 import com.backend.immilog.post.domain.enums.Categories;
+import com.backend.immilog.post.domain.enums.Countries;
 import com.backend.immilog.post.domain.enums.PostStatus;
 import com.backend.immilog.post.exception.PostErrorCode;
 import com.backend.immilog.post.exception.PostException;
@@ -199,4 +200,28 @@ public class Post {
                 .build();
     }
 
+    public static Post from(PostResult postResult) {
+        return Post.builder()
+                .seq(postResult.getSeq())
+                .postUserInfo(new PostUserInfo(
+                        postResult.getUserSeq(),
+                        postResult.getUserProfileUrl(),
+                        postResult.getUserNickName()
+                ))
+                .postInfo(new PostInfo(
+                        postResult.getTitle(),
+                        postResult.getContent(),
+                        postResult.getViewCount(),
+                        postResult.getLikeCount(),
+                        postResult.getRegion(),
+                        postResult.getStatus(),
+                        Countries.valueOf(postResult.getCountry())
+                ))
+                .category(postResult.getCategory())
+                .isPublic(postResult.getIsPublic())
+                .commentCount(postResult.getCommentCount())
+                .createdAt(LocalDateTime.parse(postResult.getCreatedAt()))
+                .updatedAt(LocalDateTime.parse(postResult.getUpdatedAt()))
+                .build();
+    }
 }

--- a/src/main/java/com/backend/immilog/post/domain/repositories/InteractionUserRepository.java
+++ b/src/main/java/com/backend/immilog/post/domain/repositories/InteractionUserRepository.java
@@ -27,5 +27,8 @@ public interface InteractionUserRepository {
             InteractionType interactionType
     );
 
-    List<InteractionUser> findAllByPostSeqList(List<Long> postSeqList);
+    List<InteractionUser> getInteractionsByPostSeqList(
+            List<Long> postSeqList,
+            PostType postType
+    );
 }

--- a/src/main/java/com/backend/immilog/post/domain/repositories/JobBoardRepository.java
+++ b/src/main/java/com/backend/immilog/post/domain/repositories/JobBoardRepository.java
@@ -1,6 +1,5 @@
 package com.backend.immilog.post.domain.repositories;
 
-import com.backend.immilog.post.application.result.JobBoardResult;
 import com.backend.immilog.post.domain.enums.Countries;
 import com.backend.immilog.post.domain.enums.Experience;
 import com.backend.immilog.post.domain.enums.Industry;
@@ -8,12 +7,10 @@ import com.backend.immilog.post.domain.model.post.JobBoard;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.Optional;
-
 public interface JobBoardRepository {
     void save(JobBoard jobBoard);
 
-    Page<JobBoardResult> getJobBoards(
+    Page<JobBoard> getJobBoards(
             Countries country,
             String sortingMethod,
             Industry industry,
@@ -21,5 +18,5 @@ public interface JobBoardRepository {
             Pageable pageable
     );
 
-    Optional<JobBoardResult> getJobBoardBySeq(Long jobBoardSeq);
+    JobBoard getJobBoardBySeq(Long jobBoardSeq);
 }

--- a/src/main/java/com/backend/immilog/post/domain/repositories/PostRepository.java
+++ b/src/main/java/com/backend/immilog/post/domain/repositories/PostRepository.java
@@ -1,6 +1,5 @@
 package com.backend.immilog.post.domain.repositories;
 
-import com.backend.immilog.post.application.result.PostResult;
 import com.backend.immilog.post.domain.enums.Categories;
 import com.backend.immilog.post.domain.enums.Countries;
 import com.backend.immilog.post.domain.enums.SortingMethods;
@@ -8,11 +7,9 @@ import com.backend.immilog.post.domain.model.post.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.Optional;
-
 public interface PostRepository {
 
-    Page<PostResult> getPosts(
+    Page<Post> getPosts(
             Countries country,
             SortingMethods sortingMethod,
             String isPublic,
@@ -20,19 +17,19 @@ public interface PostRepository {
             Pageable pageable
     );
 
-    Optional<PostResult> getPostDetail(Long postSeq);
+    Post getPostDetail(Long postSeq);
 
-    Page<PostResult> getPostsByKeyword(
+    Page<Post> getPostsByKeyword(
             String keyword,
             Pageable pageable
     );
 
-    Page<PostResult> getPostsByUserSeq(
+    Page<Post> getPostsByUserSeq(
             Long userSeq,
             Pageable pageable
     );
 
-    Optional<Post> getById(Long postSeq);
+    Post getById(Long postSeq);
 
     Post save(Post postEntity);
 

--- a/src/main/java/com/backend/immilog/post/domain/repositories/PostResourceRepository.java
+++ b/src/main/java/com/backend/immilog/post/domain/repositories/PostResourceRepository.java
@@ -18,5 +18,8 @@ public interface PostResourceRepository {
 
     List<PostResource> findAllByPostSeq(Long seq);
 
-    List<PostResource> findAllByPostSeqList(List<Long> postSeqList);
+    List<PostResource> findAllByPostSeqList(
+            List<Long> postSeqList,
+            PostType postType
+    );
 }

--- a/src/main/java/com/backend/immilog/post/infrastructure/jdbc/InteractionUserJdbcRepository.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/jdbc/InteractionUserJdbcRepository.java
@@ -1,5 +1,6 @@
 package com.backend.immilog.post.infrastructure.jdbc;
 
+import com.backend.immilog.post.domain.enums.PostType;
 import com.backend.immilog.post.domain.model.interaction.InteractionUser;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
@@ -14,11 +15,15 @@ public class InteractionUserJdbcRepository {
         this.jdbcClient = jdbcClient;
     }
 
-    public List<InteractionUser> findAllByPostSeqList(List<Long> postSeqList) {
+    public List<InteractionUser> findAllByPostSeqList(
+            List<Long> postSeqList,
+            PostType postType
+    ) {
         return jdbcClient.sql("""
                         SELECT *
                         FROM interaction_user
                         WHERE post_seq IN (:postSeqList)
+                        AND post_type = :postType
                         """)
                 .params(postSeqList)
                 .query(InteractionUser.class)

--- a/src/main/java/com/backend/immilog/post/infrastructure/jdbc/JobBoardJdbcRepository.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/jdbc/JobBoardJdbcRepository.java
@@ -1,0 +1,68 @@
+package com.backend.immilog.post.infrastructure.jdbc;
+
+import com.backend.immilog.post.domain.enums.Countries;
+import com.backend.immilog.post.domain.enums.Experience;
+import com.backend.immilog.post.domain.enums.Industry;
+import com.backend.immilog.post.infrastructure.jpa.entity.post.JobBoardEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class JobBoardJdbcRepository {
+    private final JdbcClient jdbcClient;
+
+    public JobBoardJdbcRepository(JdbcClient jdbcClient) {
+        this.jdbcClient = jdbcClient;
+    }
+
+    public List<JobBoardEntity> getJobBoards(
+            Countries country,
+            String sortingMethod,
+            Industry industry,
+            Experience experience,
+            Pageable pageable
+    ) {
+        String sql = """
+                SELECT * 
+                FROM job_board
+                WHERE country = ?
+                AND industry = ?
+                AND experience = ?
+                ORDER BY """ + sortingMethod + """
+                LIMIT ?
+                OFFSET ?
+                """;
+        return jdbcClient.sql(sql)
+                .param(country)
+                .param(industry)
+                .param(experience)
+                .param(pageable.getPageSize())
+                .param(pageable.getOffset())
+                .query(JobBoardEntity.class)
+                .list();
+
+    }
+
+    public Integer getTotal(
+            Countries country,
+            Industry industry,
+            Experience experience
+    ) {
+        return jdbcClient.sql("""
+                        SELECT COUNT(*) 
+                        FROM job_board
+                        WHERE country = ?
+                        AND industry = ?
+                        AND experience = ?
+                        """)
+                .param(country)
+                .param(industry)
+                .param(experience)
+                .query(Integer.class)
+                .single();
+
+    }
+}

--- a/src/main/java/com/backend/immilog/post/infrastructure/jdbc/PostJdbcRepository.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/jdbc/PostJdbcRepository.java
@@ -1,10 +1,10 @@
 package com.backend.immilog.post.infrastructure.jdbc;
 
-import com.backend.immilog.post.application.result.PostResult;
 import com.backend.immilog.post.domain.enums.Categories;
 import com.backend.immilog.post.domain.enums.Countries;
 import com.backend.immilog.post.domain.enums.SortingMethods;
 import com.backend.immilog.post.domain.model.post.Post;
+import com.backend.immilog.post.infrastructure.jpa.entity.post.PostEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -21,7 +21,7 @@ public class PostJdbcRepository {
 
     public PostJdbcRepository(JdbcClient jdbcClient) {this.jdbcClient = jdbcClient;}
 
-    public Page<PostResult> getPostResults(
+    public Page<Post> getPosts(
             Countries country,
             SortingMethods sortingMethod,
             String isPublic,
@@ -39,13 +39,13 @@ public class PostJdbcRepository {
                 OFFSET ?
                 """;
 
-        List<Post> posts = jdbcClient.sql(sql)
+        List<PostEntity> posts = jdbcClient.sql(sql)
                 .param(country)
                 .param(isPublic)
                 .param(category)
                 .param(pageable.getPageSize())
                 .param(pageable.getOffset())
-                .query(Post.class)
+                .query(PostEntity.class)
                 .list();
 
         int count = jdbcClient.sql("""
@@ -62,13 +62,13 @@ public class PostJdbcRepository {
                 .single();
 
         return new PageImpl<>(
-                posts.stream().map(Post::toResult).toList(),
+                posts.stream().map(PostEntity::toDomain).toList(),
                 pageable,
                 count
         );
     }
 
-    public Page<PostResult> getPostsByUserSeq(
+    public Page<Post> getPostsByUserSeq(
             Long userSeq,
             Pageable pageable
     ) {
@@ -81,11 +81,11 @@ public class PostJdbcRepository {
                 OFFSET ?
                 """;
 
-        List<Post> posts = jdbcClient.sql(sql)
+        List<PostEntity> posts = jdbcClient.sql(sql)
                 .param(userSeq)
                 .param(pageable.getPageSize())
                 .param(pageable.getOffset())
-                .query(Post.class)
+                .query(PostEntity.class)
                 .list();
 
         int count = jdbcClient.sql("""
@@ -98,7 +98,7 @@ public class PostJdbcRepository {
                 .single();
 
         return new PageImpl<>(
-                posts.stream().map(Post::toResult).toList(),
+                posts.stream().map(PostEntity::toDomain).toList(),
                 pageable,
                 count
         );
@@ -116,7 +116,7 @@ public class PostJdbcRepository {
                 """.formatted(column);
     }
 
-    public Page<PostResult> getPostsByKeyword(
+    public Page<Post> getPostsByKeyword(
             String keyword,
             Pageable pageable
     ) {
@@ -128,12 +128,12 @@ public class PostJdbcRepository {
                 LIMIT ?
                 OFFSET ?
                 """;
-        List<Post> posts = jdbcClient.sql(sql)
+        List<PostEntity> posts = jdbcClient.sql(sql)
                 .param("%" + keyword + "%")
                 .param("%" + keyword + "%")
                 .param(pageable.getPageSize())
                 .param(pageable.getOffset())
-                .query(Post.class)
+                .query(PostEntity.class)
                 .list();
 
         int count = jdbcClient.sql("""
@@ -148,13 +148,13 @@ public class PostJdbcRepository {
                 .single();
 
         return new PageImpl<>(
-                posts.stream().map(Post::toResult).toList(),
+                posts.stream().map(PostEntity::toDomain).toList(),
                 pageable,
                 count
         );
     }
 
-    public Optional<PostResult> getSinglePost(Long postSeq) {
+    public Optional<Post> getSinglePost(Long postSeq) {
         String sql = """
                 SELECT * 
                 FROM post
@@ -163,12 +163,12 @@ public class PostJdbcRepository {
 
         return Optional.of(jdbcClient.sql(sql)
                 .param(postSeq)
-                .query(Post.class)
+                .query(PostEntity.class)
                 .single()
-                .toResult());
+                .toDomain());
     }
 
-    public List<PostResult> getPopularPosts(
+    public List<Post> getPopularPosts(
             LocalDateTime from,
             LocalDateTime to,
             SortingMethods sortingMethods
@@ -184,10 +184,10 @@ public class PostJdbcRepository {
         return jdbcClient.sql(sql)
                 .param(from)
                 .param(to)
-                .query(Post.class)
+                .query(PostEntity.class)
                 .list()
                 .stream()
-                .map(Post::toResult)
+                .map(PostEntity::toDomain)
                 .toList();
     }
 }

--- a/src/main/java/com/backend/immilog/post/infrastructure/jdbc/PostResourceJdbcRepository.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/jdbc/PostResourceJdbcRepository.java
@@ -52,11 +52,15 @@ public class PostResourceJdbcRepository {
                 .update();
     }
 
-    public List<PostResource> findAllByPostSeqList(List<Long> postSeqList){
+    public List<PostResource> findAllByPostSeqList(
+            List<Long> postSeqList,
+            PostType postType
+    ) {
         return jdbcClient.sql("""
                         SELECT *
                         FROM post_resource
                         WHERE post_seq IN (:postSeqList)
+                        AND post_type = :postType
                         """)
                 .params(postSeqList)
                 .query(PostResource.class)

--- a/src/main/java/com/backend/immilog/post/infrastructure/repositories/InteractionUserRepositoryImpl.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/repositories/InteractionUserRepositoryImpl.java
@@ -59,7 +59,10 @@ public class InteractionUserRepositoryImpl implements InteractionUserRepository 
     }
 
     @Override
-    public List<InteractionUser> findAllByPostSeqList(List<Long> postSeqList) {
-        return interactionUserJdbcRepository.findAllByPostSeqList(postSeqList);
+    public List<InteractionUser> getInteractionsByPostSeqList(
+            List<Long> postSeqList,
+            PostType postType
+    ) {
+        return interactionUserJdbcRepository.findAllByPostSeqList(postSeqList, postType);
     }
 }

--- a/src/main/java/com/backend/immilog/post/infrastructure/repositories/JobBoardRepositoryImpl.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/repositories/JobBoardRepositoryImpl.java
@@ -1,25 +1,33 @@
 package com.backend.immilog.post.infrastructure.repositories;
 
-import com.backend.immilog.post.application.result.JobBoardResult;
 import com.backend.immilog.post.domain.enums.Countries;
 import com.backend.immilog.post.domain.enums.Experience;
 import com.backend.immilog.post.domain.enums.Industry;
 import com.backend.immilog.post.domain.model.post.JobBoard;
 import com.backend.immilog.post.domain.repositories.JobBoardRepository;
+import com.backend.immilog.post.exception.PostErrorCode;
+import com.backend.immilog.post.exception.PostException;
+import com.backend.immilog.post.infrastructure.jdbc.JobBoardJdbcRepository;
 import com.backend.immilog.post.infrastructure.jpa.entity.post.JobBoardEntity;
 import com.backend.immilog.post.infrastructure.jpa.repository.JobBoardJpaRepository;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import java.util.List;
 
 @Repository
 public class JobBoardRepositoryImpl implements JobBoardRepository {
     private final JobBoardJpaRepository jobBoardJpaRepository;
+    private final JobBoardJdbcRepository jobBoardJdbcRepository;
 
-    public JobBoardRepositoryImpl(JobBoardJpaRepository jobBoardJpaRepository) {
+    public JobBoardRepositoryImpl(
+            JobBoardJpaRepository jobBoardJpaRepository,
+            JobBoardJdbcRepository jobBoardJdbcRepository
+    ) {
         this.jobBoardJpaRepository = jobBoardJpaRepository;
+        this.jobBoardJdbcRepository = jobBoardJdbcRepository;
     }
 
     @Override
@@ -28,164 +36,23 @@ public class JobBoardRepositoryImpl implements JobBoardRepository {
     }
 
     @Override
-    public Page<JobBoardResult> getJobBoards(
+    public Page<JobBoard> getJobBoards(
             Countries country,
             String sortingMethod,
             Industry industry,
             Experience experience,
             Pageable pageable
     ) {
-//        QJobBoardEntity jobBoard = QJobBoardEntity.jobBoardEntity;
-//        QPostResourceEntity resource = QPostResourceEntity.postResourceEntity;
-//        QInteractionUserEntity interUser = QInteractionUserEntity.interactionUserEntity;
-//
-//        BooleanBuilder predicateBuilder = new BooleanBuilder();
-//        com.backend.immilog.user.domain.enums.Industry industryEnum = convertToUserIndustry(industry);
-//
-//        if (isNotNullAndSame(industry, Industry.ALL)) {
-//            predicateBuilder.and(jobBoard.companyMetaData.industry.eq(industryEnum));
-//        }
-//        if (isNotNullAndSame(country, Countries.ALL)) {
-//            predicateBuilder.and(jobBoard.postMetaData.country.eq(country));
-//        }
-//        if (isNotNullAndSame(experience, Experience.ALL)) {
-//            predicateBuilder.and(jobBoard.companyMetaData.experience.eq(experience));
-//        }
-//
-//        // 정렬 조건 설정
-//        OrderSpecifier<?> orderSpecifier = getOrderSpecifier(sortingMethod, jobBoard);
-//
-//        long total = getLength(predicateBuilder);
-//        List<JobBoardResult> jobBoards = jpaQueryFactory
-//                .select(jobBoard, list(interUser), list(resource))
-//                .from(jobBoard)
-//                .leftJoin(resource)
-//                .on(resource.postSeq.eq(jobBoard.seq).and(resource.postType.eq(JOB_BOARD)))
-//                .leftJoin(interUser)
-//                .on(interUser.postSeq.eq(jobBoard.seq).and(interUser.postType.eq(JOB_BOARD)))
-//                .where(predicateBuilder)
-//                .orderBy(orderSpecifier)
-//                .offset(pageable.getOffset())
-//                .limit(pageable.getPageSize())
-//                .transform(
-//                        groupBy(jobBoard.seq).list(
-//                                Projections.constructor(
-//                                        JobBoardEntityResult.class,
-//                                        jobBoard.seq,
-//                                        jobBoard.postMetaData.title,
-//                                        jobBoard.postMetaData.content,
-//                                        jobBoard.postMetaData.viewCount,
-//                                        jobBoard.postMetaData.likeCount,
-//                                        list(resource),
-//                                        list(interUser),
-//                                        jobBoard.postMetaData.country,
-//                                        jobBoard.postMetaData.region,
-//                                        jobBoard.companyMetaData.companySeq,
-//                                        jobBoard.companyMetaData.industry,
-//                                        jobBoard.companyMetaData.deadline,
-//                                        jobBoard.companyMetaData.experience,
-//                                        jobBoard.companyMetaData.salary,
-//                                        jobBoard.companyMetaData.company,
-//                                        jobBoard.companyMetaData.email,
-//                                        jobBoard.companyMetaData.phone,
-//                                        jobBoard.companyMetaData.address,
-//                                        jobBoard.companyMetaData.homepage,
-//                                        jobBoard.companyMetaData.logo,
-//                                        jobBoard.postMetaData.status,
-//                                        jobBoard.createdAt
-//                                )
-//                        )
-//                )
-//                .stream()
-//                .map(JobBoardEntityResult::toResult)
-//                .toList();
-//
-//        return new PageImpl<>(jobBoards, pageable, total);
-        return null;
+        List<JobBoardEntity> entities = jobBoardJdbcRepository.getJobBoards(country, sortingMethod, industry, experience, pageable);
+        Integer total = jobBoardJdbcRepository.getTotal(country, industry, experience);
+        List<JobBoard> jobBoards = entities.stream().map(JobBoardEntity::toDomain).toList();
+        return new PageImpl<>(jobBoards, pageable, total);
     }
 
     @Override
-    public Optional<JobBoardResult> getJobBoardBySeq(
-            Long jobBoardSeq
-    ) {
-        return null;
-//        QJobBoardEntity jobBoard = QJobBoardEntity.jobBoardEntity;
-//        QPostResourceEntity resource = QPostResourceEntity.postResourceEntity;
-//        QInteractionUserEntity interUser = QInteractionUserEntity.interactionUserEntity;
-//
-//        return jpaQueryFactory
-//                .select(jobBoard, list(interUser), list(resource))
-//                .from(jobBoard)
-//                .leftJoin(resource)
-//                .on(resource.postSeq.eq(jobBoard.seq).and(resource.postType.eq(JOB_BOARD)))
-//                .leftJoin(interUser)
-//                .on(interUser.postSeq.eq(jobBoard.seq).and(interUser.postType.eq(JOB_BOARD)))
-//                .where(jobBoard.seq.eq(jobBoardSeq))
-//                .transform(
-//                        groupBy(jobBoard.seq).list(
-//                                Projections.constructor(
-//                                        JobBoardEntityResult.class,
-//                                        jobBoard.seq,
-//                                        jobBoard.postMetaData.title,
-//                                        jobBoard.postMetaData.content,
-//                                        jobBoard.postMetaData.viewCount,
-//                                        jobBoard.postMetaData.likeCount,
-//                                        list(resource),
-//                                        list(interUser),
-//                                        jobBoard.postMetaData.country,
-//                                        jobBoard.postMetaData.region,
-//                                        jobBoard.companyMetaData.companySeq,
-//                                        jobBoard.companyMetaData.industry,
-//                                        jobBoard.companyMetaData.deadline,
-//                                        jobBoard.companyMetaData.experience,
-//                                        jobBoard.companyMetaData.salary,
-//                                        jobBoard.companyMetaData.company,
-//                                        jobBoard.companyMetaData.email,
-//                                        jobBoard.companyMetaData.phone,
-//                                        jobBoard.companyMetaData.address,
-//                                        jobBoard.companyMetaData.homepage,
-//                                        jobBoard.companyMetaData.logo,
-//                                        jobBoard.postMetaData.status,
-//                                        jobBoard.createdAt
-//                                )
-//                        )
-//                )
-//                .stream()
-//                .findFirst()
-//                .map(JobBoardEntityResult::toResult);
+    public JobBoard getJobBoardBySeq(Long jobBoardSeq) {
+        return jobBoardJpaRepository.findById(jobBoardSeq)
+                .orElseThrow(() -> new PostException(PostErrorCode.JOB_BOARD_NOT_FOUND))
+                .toDomain();
     }
-//
-//    private Long getLength(
-//            Predicate predicate
-//    ) {
-//        QJobBoardEntity jobBoard = QJobBoardEntity.jobBoardEntity;
-//        return (long) jpaQueryFactory.selectFrom(jobBoard)
-//                .where(predicate)
-//                .fetch()
-//                .size();
-//    }
-//
-//    private OrderSpecifier<?> getOrderSpecifier(
-//            String sortingMethod,
-//            QJobBoardEntity jobBoard
-//    ) {
-//        return switch (SortingMethods.valueOf(sortingMethod)) {
-//            case VIEW_COUNT -> jobBoard.postMetaData.viewCount.desc();
-//            case LIKE_COUNT -> jobBoard.postMetaData.likeCount.desc();
-//            default -> jobBoard.createdAt.desc();
-//        };
-//    }
-//
-//
-//    private static com.backend.immilog.user.domain.enums.Industry convertToUserIndustry(Industry industry) {
-//        return com.backend.immilog.user.domain.enums.Industry.valueOf(industry.name());
-//    }
-//
-//    private <T, E extends Enum<E>> boolean isNotNullAndSame(
-//            E value,
-//            T compare
-//    ) {
-//        return Objects.equals(value, compare);
-//    }
-
 }

--- a/src/main/java/com/backend/immilog/post/infrastructure/repositories/PopularPostRepositoryImpl.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/repositories/PopularPostRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.backend.immilog.post.infrastructure.repositories;
 import com.backend.immilog.global.infrastructure.persistence.repository.RedisDataRepository;
 import com.backend.immilog.post.application.result.PostResult;
 import com.backend.immilog.post.domain.enums.SortingMethods;
+import com.backend.immilog.post.domain.model.post.Post;
 import com.backend.immilog.post.domain.repositories.PopularPostRepository;
 import com.backend.immilog.post.infrastructure.jdbc.PostJdbcRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -53,11 +54,12 @@ public class PopularPostRepositoryImpl implements PopularPostRepository {
             LocalDateTime from,
             LocalDateTime to
     ) {
-        return postJdbcRepository.getPopularPosts(
+        List<Post> posts = postJdbcRepository.getPopularPosts(
                 from,
                 to,
                 SortingMethods.VIEW_COUNT
         );
+        return posts.stream().map(Post::toResult).toList();
     }
 
     @Override
@@ -65,10 +67,11 @@ public class PopularPostRepositoryImpl implements PopularPostRepository {
             LocalDateTime from,
             LocalDateTime to
     ) {
-        return postJdbcRepository.getPopularPosts(
+        List<Post> posts = postJdbcRepository.getPopularPosts(
                 from,
                 to,
                 SortingMethods.COMMENT_COUNT
         );
+        return posts.stream().map(Post::toResult).toList();
     }
 }

--- a/src/main/java/com/backend/immilog/post/infrastructure/repositories/PostRepositoryImpl.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/repositories/PostRepositoryImpl.java
@@ -1,15 +1,12 @@
 package com.backend.immilog.post.infrastructure.repositories;
 
-import com.backend.immilog.post.application.result.PostResult;
 import com.backend.immilog.post.domain.enums.Categories;
 import com.backend.immilog.post.domain.enums.Countries;
 import com.backend.immilog.post.domain.enums.SortingMethods;
-import com.backend.immilog.post.domain.model.interaction.InteractionUser;
 import com.backend.immilog.post.domain.model.post.Post;
-import com.backend.immilog.post.domain.model.resource.PostResource;
-import com.backend.immilog.post.domain.repositories.InteractionUserRepository;
 import com.backend.immilog.post.domain.repositories.PostRepository;
-import com.backend.immilog.post.domain.repositories.PostResourceRepository;
+import com.backend.immilog.post.exception.PostErrorCode;
+import com.backend.immilog.post.exception.PostException;
 import com.backend.immilog.post.infrastructure.jdbc.PostJdbcRepository;
 import com.backend.immilog.post.infrastructure.jpa.entity.post.PostEntity;
 import com.backend.immilog.post.infrastructure.jpa.repository.PostJpaRepository;
@@ -17,145 +14,69 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
+import static com.backend.immilog.post.exception.PostErrorCode.POST_NOT_FOUND;
 
 @Repository
 public class PostRepositoryImpl implements PostRepository {
     private final PostJdbcRepository postJdbcRepository;
     private final PostJpaRepository postJpaRepository;
-    private final PostResourceRepository postResourceRepository;
-    private final InteractionUserRepository interactionUserRepository;
 
     public PostRepositoryImpl(
             PostJdbcRepository postJdbcRepository,
-            PostJpaRepository postJpaRepository,
-            PostResourceRepository postResourceRepository,
-            InteractionUserRepository interactionUserRepository
+            PostJpaRepository postJpaRepository
     ) {
         this.postJdbcRepository = postJdbcRepository;
         this.postJpaRepository = postJpaRepository;
-        this.postResourceRepository = postResourceRepository;
-        this.interactionUserRepository = interactionUserRepository;
     }
 
     @Override
-    public Page<PostResult> getPosts(
+    public Page<Post> getPosts(
             Countries country,
             SortingMethods sortingMethod,
             String isPublic,
             Categories category,
             Pageable pageable
     ) {
-        Page<PostResult> postResults = postJdbcRepository.getPostResults(country, sortingMethod, isPublic, category, pageable);
+        return postJdbcRepository.getPosts(
+                country,
+                sortingMethod,
+                isPublic,
+                category,
+                pageable
+        );
+    }
 
-        List<Long> postSeqList = postResults.stream()
-                .map(PostResult::getSeq)
-                .toList();
 
-        List<PostResource> postResources = postResourceRepository.findAllByPostSeqList(postSeqList);
-        List<InteractionUser> interactionUsers = interactionUserRepository.findAllByPostSeqList(postSeqList);
-
-        return postResults.map(postResult -> {
-            List<PostResource> resources = postResources.stream()
-                    .filter(postResource -> postResource.getPostSeq().equals(postResult.getSeq()))
-                    .toList();
-
-            List<InteractionUser> interactionUserList = interactionUsers.stream()
-                    .filter(interactionUser -> interactionUser.getPostSeq().equals(postResult.getSeq()))
-                    .toList();
-
-            postResult.addInteractionUsers(interactionUserList);
-            postResult.addResources(resources);
-
-            return postResult;
-        });
+    @Override
+    public Post getPostDetail(Long postSeq) {
+        return postJdbcRepository
+                .getSinglePost(postSeq)
+                .orElseThrow(() -> new PostException(POST_NOT_FOUND));
     }
 
     @Override
-    public Optional<PostResult> getPostDetail(Long postSeq) {
-        Optional<PostResult> post = postJdbcRepository.getSinglePost(postSeq);
-        List<Long> postSeqList = List.of(postSeq);
-
-        List<PostResource> postResources = postResourceRepository.findAllByPostSeqList(postSeqList);
-        List<InteractionUser> interactionUsers = interactionUserRepository.findAllByPostSeqList(postSeqList);
-
-        return post.map(postResult -> {
-            List<PostResource> resources = postResources.stream()
-                    .filter(postResource -> postResource.getPostSeq().equals(postResult.getSeq()))
-                    .toList();
-
-            List<InteractionUser> interactionUserList = interactionUsers.stream()
-                    .filter(interactionUser -> interactionUser.getPostSeq().equals(postResult.getSeq()))
-                    .toList();
-
-            postResult.addInteractionUsers(interactionUserList);
-            postResult.addResources(resources);
-
-            return postResult;
-        });
-    }
-
-    @Override
-    public Page<PostResult> getPostsByKeyword(
+    public Page<Post> getPostsByKeyword(
             String keyword,
             Pageable pageable
     ) {
-        Page<PostResult> posts = postJdbcRepository.getPostsByKeyword(keyword, pageable);
-        posts.getContent().forEach(post -> post.addKeywords(keyword));
-
-        List<Long> postSeqList = posts.stream().map(PostResult::getSeq).toList();
-
-        List<PostResource> postResources = postResourceRepository.findAllByPostSeqList(postSeqList);
-        List<InteractionUser> interactionUsers = interactionUserRepository.findAllByPostSeqList(postSeqList);
-
-        return posts.map(postResult -> {
-            List<PostResource> resources = postResources.stream()
-                    .filter(postResource -> postResource.getPostSeq().equals(postResult.getSeq()))
-                    .toList();
-
-            List<InteractionUser> interactionUserList = interactionUsers.stream()
-                    .filter(interactionUser -> interactionUser.getPostSeq().equals(postResult.getSeq()))
-                    .toList();
-
-            postResult.addInteractionUsers(interactionUserList);
-            postResult.addResources(resources);
-
-            return postResult;
-        });
+        return postJdbcRepository.getPostsByKeyword(keyword, pageable);
     }
 
     @Override
-    public Page<PostResult> getPostsByUserSeq(
+    public Page<Post> getPostsByUserSeq(
             Long userSeq,
             Pageable pageable
     ) {
-        Page<PostResult> posts = postJdbcRepository.getPostsByUserSeq(userSeq, pageable);
-        List<Long> postSeqList = posts.stream()
-                .map(PostResult::getSeq)
-                .toList();
-
-        List<PostResource> postResources = postResourceRepository.findAllByPostSeqList(postSeqList);
-        List<InteractionUser> interactionUsers = interactionUserRepository.findAllByPostSeqList(postSeqList);
-
-        return posts.map(postResult -> {
-            List<PostResource> resources = postResources.stream()
-                    .filter(postResource -> postResource.getPostSeq().equals(postResult.getSeq()))
-                    .toList();
-
-            List<InteractionUser> interactionUserList = interactionUsers.stream()
-                    .filter(interactionUser -> interactionUser.getPostSeq().equals(postResult.getSeq()))
-                    .toList();
-
-            postResult.addInteractionUsers(interactionUserList);
-            postResult.addResources(resources);
-
-            return postResult;
-        });
+        return postJdbcRepository.getPostsByUserSeq(userSeq, pageable);
     }
 
     @Override
-    public Optional<Post> getById(Long postSeq) {return postJpaRepository.findById(postSeq).map(PostEntity::toDomain);}
+    public Post getById(Long postSeq) {
+        return postJpaRepository
+                .findById(postSeq)
+                .map(PostEntity::toDomain)
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+    }
 
     @Override
     public Post save(Post post) {

--- a/src/main/java/com/backend/immilog/post/infrastructure/repositories/PostResourceRepositoryImpl.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/repositories/PostResourceRepositoryImpl.java
@@ -53,7 +53,10 @@ public class PostResourceRepositoryImpl implements PostResourceRepository {
     }
 
     @Override
-    public List<PostResource> findAllByPostSeqList(List<Long> postSeqList) {
-        return postResourceJdbcRepository.findAllByPostSeqList(postSeqList);
+    public List<PostResource> findAllByPostSeqList(
+            List<Long> postSeqList,
+            PostType postType
+    ) {
+        return postResourceJdbcRepository.findAllByPostSeqList(postSeqList, postType);
     }
 }


### PR DESCRIPTION
### 작업 내용
- 기존에는 queryDSL사용으로 하나의 repository에서 연관된 (물리적으로는 분리되어있었음) 
엔티티 함게 조회하여 레포지토리에서 dto생성하여 반환
- 각 repository 에서 해당되는 한 가지 엔티티만 조회
- queryService 조회된 엔티티 조합 및 DTO 반환
- 결과적으로 책임분리 / 유지보수성 및 확장성 증대

### 특이 사항
- 금일 작업시간 부족으로 테스트 미실시
-  추후 테스트코드 수정 및 코드수정 + 커밋예정
