### PR TITLE
댓글 좋아요 인터렉션 추가 / 조회 이슈 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,8 @@ dependencies {
     // Kotlin dependencies: 버전 없이 지정하면 플러그인 버전과 맞춰줌
     implementation "org.jetbrains.kotlin:kotlin-reflect"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 def generatedDir = "$buildDir/main/generated"

--- a/src/main/java/com/backend/immilog/global/configuration/JacksonConfig.java
+++ b/src/main/java/com/backend/immilog/global/configuration/JacksonConfig.java
@@ -1,0 +1,18 @@
+package com.backend.immilog.global.configuration;
+
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jackson2ObjectMapperBuilderCustomizer() {
+        return builder -> {
+            builder.modules(new JavaTimeModule());
+            builder.featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        };
+    }
+}

--- a/src/main/java/com/backend/immilog/post/application/result/CommentResult.java
+++ b/src/main/java/com/backend/immilog/post/application/result/CommentResult.java
@@ -5,7 +5,6 @@ import com.backend.immilog.post.domain.model.comment.Comment;
 import com.backend.immilog.user.application.result.UserInfoResult;
 import com.backend.immilog.user.domain.model.user.User;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -20,7 +19,7 @@ public record CommentResult(
         int replyCount,
         List<Long> likeUsers,
         PostStatus status,
-        LocalDateTime createdAt
+        String createdAt
 ) {
     public static CommentResult of(
             Comment comment,
@@ -36,7 +35,7 @@ public record CommentResult(
                 comment.replyCount(),
                 comment.likeUsers(),
                 comment.status(),
-                comment.createdAt()
+                comment.createdAt().toString()
         );
     }
 
@@ -61,5 +60,35 @@ public record CommentResult(
 
     public void addChildComment(CommentResult childComment) {
         this.replies.add(childComment);
+    }
+
+    public CommentResult updateLikeCount(Integer likeCount) {
+        return new CommentResult(
+                seq,
+                user,
+                content,
+                replies,
+                likeCount,
+                downVotes,
+                replyCount,
+                likeUsers,
+                status,
+                createdAt
+        );
+    }
+
+    public CommentResult updateLikeUsers(List<Long> likeUsers) {
+        return new CommentResult(
+                seq,
+                user,
+                content,
+                replies,
+                upVotes,
+                downVotes,
+                replyCount,
+                likeUsers,
+                status,
+                createdAt
+        );
     }
 }

--- a/src/main/java/com/backend/immilog/post/application/services/CommentUploadService.java
+++ b/src/main/java/com/backend/immilog/post/application/services/CommentUploadService.java
@@ -34,10 +34,10 @@ public class CommentUploadService {
             String referenceType,
             String content
     ) {
-        Post post = postQueryService.getPostById(postSeq);
-        Post deletedPost = post.updateCommentCount();
-        ReferenceType reference = ReferenceType.getByString(referenceType);
-        Comment comment = Comment.of(userId, postSeq, content, reference);
+        final Post post = postQueryService.getPostById(postSeq);
+        final Post deletedPost = post.increaseCommentCount();
+        final ReferenceType reference = ReferenceType.getByString(referenceType);
+        final Comment comment = Comment.of(userId, postSeq, content, reference);
         postCommandService.save(deletedPost);
         commentCommandService.save(comment);
     }

--- a/src/main/java/com/backend/immilog/post/application/services/InteractionCreationService.java
+++ b/src/main/java/com/backend/immilog/post/application/services/InteractionCreationService.java
@@ -6,7 +6,6 @@ import com.backend.immilog.post.domain.enums.InteractionType;
 import com.backend.immilog.post.domain.enums.PostType;
 import com.backend.immilog.post.domain.model.interaction.InteractionUser;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,7 +23,6 @@ public class InteractionCreationService {
         this.interactionUserQueryService = interactionUserQueryService;
     }
 
-    @Async
     @Transactional
     public void createInteraction(
             Long userSeq,
@@ -32,22 +30,11 @@ public class InteractionCreationService {
             PostType postType,
             InteractionType interactionType
     ) {
-        interactionUserQueryService.getByPostSeqAndUserSeqAndPostTypeAndInteractionType(
-                        postSeq,
-                        userSeq,
-                        postType,
-                        interactionType
-                )
+        interactionUserQueryService
+                .getInteraction(postSeq, userSeq, postType, interactionType)
                 .ifPresentOrElse(
                         interactionUserCommandService::delete,
-                        () -> interactionUserCommandService.save(
-                                InteractionUser.of(
-                                        postSeq,
-                                        postType,
-                                        interactionType,
-                                        userSeq
-                                )
-                        )
+                        () -> interactionUserCommandService.save(InteractionUser.of(postSeq, postType, interactionType, userSeq))
                 );
     }
 }

--- a/src/main/java/com/backend/immilog/post/application/services/PostInquiryService.java
+++ b/src/main/java/com/backend/immilog/post/application/services/PostInquiryService.java
@@ -38,7 +38,7 @@ public class PostInquiryService {
             Categories category,
             Integer page
     ) {
-        Pageable pageable = PageRequest.of(Objects.requireNonNullElse(page, 0), 10);
+        final Pageable pageable = PageRequest.of(Objects.requireNonNullElse(page, 0), 10);
         return postQueryService.getPosts(
                 country,
                 sortingMethod,
@@ -50,8 +50,8 @@ public class PostInquiryService {
 
     @Transactional(readOnly = true)
     public PostResult getPostDetail(Long postSeq) {
-        PostResult post = postQueryService.getPostDetail(postSeq);
-        List<CommentResult> comments = commentQueryService.getComments(postSeq);
+        final PostResult post = postQueryService.getPostDetail(postSeq);
+        final List<CommentResult> comments = commentQueryService.getComments(postSeq);
         post.addComments(comments);
         return post;
     }
@@ -60,8 +60,8 @@ public class PostInquiryService {
             String keyword,
             Integer page
     ) {
-        PageRequest pageRequest = PageRequest.of(page, 10);
-        Page<PostResult> posts = postQueryService.getPostsByKeyword(keyword, pageRequest);
+        final Pageable pageable = PageRequest.of(page, 10);
+        final Page<PostResult> posts = postQueryService.getPostsByKeyword(keyword, pageable);
         posts.getContent().forEach(post -> post.addKeywords(keyword));
         return posts;
     }
@@ -70,7 +70,7 @@ public class PostInquiryService {
             Long userSeq,
             Integer page
     ) {
-        Pageable pageable = PageRequest.of(Objects.requireNonNullElse(page, 0), 10);
+        final Pageable pageable = PageRequest.of(Objects.requireNonNullElse(page, 0), 10);
         return postQueryService.getPostsByUserSeq(userSeq, pageable);
     }
 

--- a/src/main/java/com/backend/immilog/post/application/services/query/CommentQueryService.java
+++ b/src/main/java/com/backend/immilog/post/application/services/query/CommentQueryService.java
@@ -1,22 +1,63 @@
 package com.backend.immilog.post.application.services.query;
 
 import com.backend.immilog.post.application.result.CommentResult;
+import com.backend.immilog.post.domain.enums.PostType;
+import com.backend.immilog.post.domain.model.comment.Comment;
+import com.backend.immilog.post.domain.model.interaction.InteractionUser;
 import com.backend.immilog.post.domain.repositories.CommentRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class CommentQueryService {
     private final CommentRepository commentRepository;
+    private final InteractionUserQueryService interactionUserQueryService;
 
-    public CommentQueryService(CommentRepository commentRepository) {
+    public CommentQueryService(
+            CommentRepository commentRepository,
+            InteractionUserQueryService interactionUserQueryService
+    ) {
         this.commentRepository = commentRepository;
+        this.interactionUserQueryService = interactionUserQueryService;
     }
 
     @Transactional(readOnly = true)
     public List<CommentResult> getComments(Long postSeq) {
-        return commentRepository.getComments(postSeq);
+        final List<CommentResult> comments = commentRepository.getComments(postSeq);
+        final List<Long> list = comments.stream().map(CommentResult::seq).toList();
+        final List<InteractionUser> interactionUsers = interactionUserQueryService.getInteractionUsersByPostSeqList(list, PostType.COMMENT);
+        final Map<Long, Integer> likeCountMap = getLikeCountMap(interactionUsers);
+        final Map<Long, List<Long>> likeUserMap = getLikeUsersMap(interactionUsers);
+        return comments.stream().map(comment -> comment
+                        .updateLikeCount(likeCountMap.getOrDefault(comment.seq(), 0))
+                        .updateLikeUsers(likeUserMap.getOrDefault(comment.seq(), List.of())))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Comment getCommentById(Long commentSeq) {
+        return commentRepository.findById(commentSeq);
+    }
+
+    private static Map<Long, List<Long>> getLikeUsersMap(List<InteractionUser> interactionUsers) {
+        return interactionUsers.stream().collect(
+                Collectors.groupingBy(
+                        InteractionUser::postSeq,
+                        Collectors.mapping(InteractionUser::userSeq, Collectors.toList())
+                )
+        );
+    }
+
+    private static Map<Long, Integer> getLikeCountMap(List<InteractionUser> interactionUsers) {
+        return interactionUsers.stream().collect(
+                Collectors.groupingBy(
+                        InteractionUser::postSeq,
+                        Collectors.collectingAndThen(Collectors.counting(), Long::intValue)
+                )
+        );
     }
 }

--- a/src/main/java/com/backend/immilog/post/application/services/query/InteractionUserQueryService.java
+++ b/src/main/java/com/backend/immilog/post/application/services/query/InteractionUserQueryService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -19,7 +20,7 @@ public class InteractionUserQueryService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<InteractionUser> getByPostSeqAndUserSeqAndPostTypeAndInteractionType(
+    public Optional<InteractionUser> getInteraction(
             Long postSeq,
             Long userSeq,
             PostType postType,

--- a/src/main/java/com/backend/immilog/post/application/services/query/PostQueryService.java
+++ b/src/main/java/com/backend/immilog/post/application/services/query/PostQueryService.java
@@ -80,10 +80,10 @@ public class PostQueryService {
     @Transactional(readOnly = true)
     public Page<PostResult> getPostsByKeyword(
             String keyword,
-            PageRequest pageRequest
+            Pageable pageable
     ) {
-        Page<Post> posts = postRepository.getPostsByKeyword(keyword, pageRequest);
-        List<Long> postSeqList = this.getSeqList(posts);
+        Page<Post> posts = postRepository.getPostsByKeyword(keyword, pageable);
+        List<Long> postSeqList = getSeqList(posts);
         Page<PostResult> postResults = posts.map(Post::toResult);
         postResults.getContent().forEach(post -> post.addKeywords(keyword));
         return this.assemblePostResult(postSeqList, postResults);
@@ -103,7 +103,7 @@ public class PostQueryService {
     ) {
         Page<Post> posts = postRepository.getPostsByUserSeq(userSeq, pageable);
         Page<PostResult> postResults = posts.map(Post::toResult);
-        return this.assemblePostResult(this.getSeqList(posts), postResults);
+        return this.assemblePostResult(getSeqList(posts), postResults);
     }
 
     public List<PostResult> getPostsFromRedis(String key) {

--- a/src/main/java/com/backend/immilog/post/domain/enums/PostType.java
+++ b/src/main/java/com/backend/immilog/post/domain/enums/PostType.java
@@ -7,7 +7,8 @@ import java.util.Arrays;
 
 public enum PostType {
     POST("posts"),
-    JOB_BOARD("jobboards");
+    JOB_BOARD("jobboards"),
+    COMMENT("comments");
 
     private final String postType;
 

--- a/src/main/java/com/backend/immilog/post/domain/model/post/Post.java
+++ b/src/main/java/com/backend/immilog/post/domain/model/post/Post.java
@@ -55,7 +55,7 @@ public record Post(
         );
     }
 
-    public Post updateCommentCount() {
+    public Post increaseCommentCount() {
         return new Post(
                 this.seq,
                 this.postUserInfo,

--- a/src/main/java/com/backend/immilog/post/domain/repositories/CommentRepository.java
+++ b/src/main/java/com/backend/immilog/post/domain/repositories/CommentRepository.java
@@ -9,4 +9,6 @@ public interface CommentRepository {
     List<CommentResult> getComments(Long postSeq);
 
     void save(Comment comment);
+
+    Comment findById(Long commentSeq);
 }

--- a/src/main/java/com/backend/immilog/post/infrastructure/jdbc/CommentJdbcRepository.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/jdbc/CommentJdbcRepository.java
@@ -15,7 +15,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -33,12 +33,12 @@ public class CommentJdbcRepository {
             UserInfoResult user
     ) {
         try {
-        String prefix = commentSeq == rs.getLong("c.seq") ? "c" : "cc";
-            String content = rs.getString(prefix + ".content");
-            int likeCount = rs.getInt(prefix + ".like_count");
-            int replyCount = rs.getInt(prefix + ".reply_count");
-            PostStatus status = PostStatus.valueOf(rs.getString(prefix + ".status"));
-            LocalDateTime localDateTime = rs.getTimestamp(prefix + ".created_at").toLocalDateTime();
+            final String prefix = commentSeq == rs.getLong("c.seq") ? "c" : "cc";
+            final String content = rs.getString(prefix + ".content");
+            final int likeCount = rs.getInt(prefix + ".like_count");
+            final int replyCount = rs.getInt(prefix + ".reply_count");
+            final PostStatus status = PostStatus.valueOf(rs.getString(prefix + ".status"));
+            final LocalDateTime localDateTime = rs.getTimestamp(prefix + ".created_at").toLocalDateTime();
             return new CommentResult(
                     commentSeq,
                     user,
@@ -49,7 +49,7 @@ public class CommentJdbcRepository {
                     replyCount,
                     new ArrayList<>(),
                     status,
-                    localDateTime
+                    localDateTime.toString()
             );
         } catch (SQLException e) {
             throw new PostException(PostErrorCode.COMMENT_NOT_FOUND);
@@ -86,7 +86,7 @@ public class CommentJdbcRepository {
                 LEFT JOIN user u ON c.user_seq = u.seq
                 LEFT JOIN comment cc ON cc.post_seq = ?
                                     AND cc.parent_seq = c.seq
-                                AND cc.reference_type = 'COMMENT'
+                                    AND cc.reference_type = 'COMMENT'
                 LEFT JOIN user cu ON cc.user_seq = cu.seq
                 WHERE c.post_seq = ?
                     AND c.parent_seq IS NULL
@@ -104,7 +104,7 @@ public class CommentJdbcRepository {
     }
 
     private List<CommentResult> mapParentCommentWithChildren(ResultSet rs) {
-        Map<Long, CommentResult> commentMap = new HashMap<>();
+        Map<Long, CommentResult> commentMap = new LinkedHashMap<>();
         try {
             do {
                 Long commentSeq = rs.getLong("c.seq");

--- a/src/main/java/com/backend/immilog/post/infrastructure/repositories/CommentRepositoryImpl.java
+++ b/src/main/java/com/backend/immilog/post/infrastructure/repositories/CommentRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.backend.immilog.post.infrastructure.repositories;
 import com.backend.immilog.post.application.result.CommentResult;
 import com.backend.immilog.post.domain.model.comment.Comment;
 import com.backend.immilog.post.domain.repositories.CommentRepository;
+import com.backend.immilog.post.exception.PostErrorCode;
+import com.backend.immilog.post.exception.PostException;
 import com.backend.immilog.post.infrastructure.jdbc.CommentJdbcRepository;
 import com.backend.immilog.post.infrastructure.jpa.entity.comment.CommentEntity;
 import com.backend.immilog.post.infrastructure.jpa.repository.CommentJpaRepository;
@@ -34,6 +36,13 @@ public class CommentRepositoryImpl implements CommentRepository {
     @Override
     public void save(Comment comment) {
         commentJpaRepository.save(CommentEntity.from(comment));
+    }
+
+    @Override
+    public Comment findById(Long commentSeq) {
+        return commentJpaRepository.findById(commentSeq)
+                .map(CommentEntity::toDomain)
+                .orElseThrow(()-> new PostException(PostErrorCode.COMMENT_NOT_FOUND));
     }
 }
 

--- a/src/test/java/com/backend/immilog/post/application/CommentUploadServiceTest.java
+++ b/src/test/java/com/backend/immilog/post/application/CommentUploadServiceTest.java
@@ -4,13 +4,11 @@ import com.backend.immilog.post.application.services.CommentUploadService;
 import com.backend.immilog.post.application.services.command.CommentCommandService;
 import com.backend.immilog.post.application.services.command.PostCommandService;
 import com.backend.immilog.post.application.services.query.PostQueryService;
-import com.backend.immilog.post.exception.PostException;
 import com.backend.immilog.post.domain.model.post.Post;
+import com.backend.immilog.post.exception.PostException;
 import com.backend.immilog.post.presentation.request.CommentUploadRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.Optional;
 
 import static com.backend.immilog.post.exception.PostErrorCode.INVALID_REFERENCE_TYPE;
 import static com.backend.immilog.post.exception.PostErrorCode.POST_NOT_FOUND;

--- a/src/test/java/com/backend/immilog/post/application/services/InteractionCreationServiceTest.java
+++ b/src/test/java/com/backend/immilog/post/application/services/InteractionCreationServiceTest.java
@@ -31,7 +31,7 @@ class InteractionCreationServiceTest {
         PostType post = PostType.POST;
         InteractionType interaction = InteractionType.LIKE;
         InteractionUser interactionUser = mock(InteractionUser.class);
-        when(interactionUserQueryService.getByPostSeqAndUserSeqAndPostTypeAndInteractionType(any(), any(), any(), any())).thenReturn(Optional.of(interactionUser));
+        when(interactionUserQueryService.getInteraction(any(), any(), any(), any())).thenReturn(Optional.of(interactionUser));
         // when
         interactionCreationService.createInteraction(userSeq, postSeq, post, interaction);
         // then
@@ -46,7 +46,7 @@ class InteractionCreationServiceTest {
         Long postSeq = 1L;
         PostType post = PostType.POST;
         InteractionType interaction = InteractionType.LIKE;
-        when(interactionUserQueryService.getByPostSeqAndUserSeqAndPostTypeAndInteractionType(any(), any(), any(), any())).thenReturn(Optional.empty());
+        when(interactionUserQueryService.getInteraction(any(), any(), any(), any())).thenReturn(Optional.empty());
         // when
         interactionCreationService.createInteraction(userSeq, postSeq, post, interaction);
         // then

--- a/src/test/java/com/backend/immilog/post/application/services/query/CommentQueryServiceTest.java
+++ b/src/test/java/com/backend/immilog/post/application/services/query/CommentQueryServiceTest.java
@@ -15,7 +15,8 @@ import static org.mockito.Mockito.when;
 class CommentQueryServiceTest {
 
     private final CommentRepository commentRepository = mock(CommentRepository.class);
-    private final CommentQueryService commentQueryService = new CommentQueryService(commentRepository);
+    private final InteractionUserQueryService interactionUserQueryService = mock(InteractionUserQueryService.class);
+    private final CommentQueryService commentQueryService = new CommentQueryService(commentRepository, interactionUserQueryService);
 
     @Test
     @DisplayName("getComments 메서드가 댓글을 성공적으로 반환")

--- a/src/test/java/com/backend/immilog/post/application/services/query/InteractionUserQueryServiceTest.java
+++ b/src/test/java/com/backend/immilog/post/application/services/query/InteractionUserQueryServiceTest.java
@@ -36,7 +36,7 @@ class InteractionUserQueryServiceTest {
         when(interactionUserRepository.getByPostSeqAndUserSeqAndPostTypeAndInteractionType(postSeq, userSeq, postType, interactionType))
                 .thenReturn(Optional.of(expectedInteractionUser));
 
-        Optional<InteractionUser> actualInteractionUser = interactionUserQueryService.getByPostSeqAndUserSeqAndPostTypeAndInteractionType(postSeq, userSeq, postType, interactionType);
+        Optional<InteractionUser> actualInteractionUser = interactionUserQueryService.getInteraction(postSeq, userSeq, postType, interactionType);
 
         assertThat(actualInteractionUser).isPresent();
         assertThat(actualInteractionUser.get()).isEqualTo(expectedInteractionUser);
@@ -52,7 +52,7 @@ class InteractionUserQueryServiceTest {
         when(interactionUserRepository.getByPostSeqAndUserSeqAndPostTypeAndInteractionType(postSeq, userSeq, postType, interactionType))
                 .thenReturn(Optional.empty());
 
-        Optional<InteractionUser> actualInteractionUser = interactionUserQueryService.getByPostSeqAndUserSeqAndPostTypeAndInteractionType(postSeq, userSeq, postType, interactionType);
+        Optional<InteractionUser> actualInteractionUser = interactionUserQueryService.getInteraction(postSeq, userSeq, postType, interactionType);
 
         assertThat(actualInteractionUser).isEmpty();
     }


### PR DESCRIPTION
### 작업 내용
- 기존 좋아요 인터렉션 추가 시 불필요한 `@Async` 로 추가되고있었음.
- 댓글 조회 시 정확한 인터렉션 조회가 이루어지지 않고있었음.
- 댓글 조회 시 인터렉션 리스트 따로 조회하여 응답 DTO 완성하여 반환하도록 수정

### 특이 사항
- 없음
